### PR TITLE
Update tag for PhysicsTools-NanoAOD to V01-03-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -23,6 +23,7 @@ PhysicsTools-PatUtils=V00-01-00
 SimTransport-PPSProtonTransport=V00-01-00
 SimTransport-TotemRPProtonTransportParametrization=V00-01-00
 
+
 #Never update any package here. Always move it to default section.
 [cmssw-xmldata-build]
 DetectorDescription-Schema=V02-02-01


### PR DESCRIPTION
Move PhysicsTools-NanoAOD data to new tag, see 
https://github.com/npc-data/PhysicsTools-NanoAOD/pull/11
and 
https://github.com/npc-data/PhysicsTools-NanoAOD/releases/tag/V01-03-00
