### PR TITLE
Update tag for PhysicsTools-NanoAOD to V01-05-00

### DIFF
--- a/data/cmsswdata.txt
+++ b/data/cmsswdata.txt
@@ -3,6 +3,7 @@
 #Once a non-default section is empty then cleanup that section and remove its cmsdist/${PACKAGE_TYPE}.file
 #If there is no customization for the packae then remove its .spec and .file
 [default]
+PhysicsTools-NanoAOD=V01-05-00
 FWCore-Modules=V00-01-00
 IOPool-Input=V00-01-00
 RecoEgamma-ElectronIdentification=V01-01-03
@@ -15,7 +16,6 @@ L1Trigger-L1THGCal=V01-00-13
 Configuration-Generator=V01-01-00
 CondTools-SiPhase2Tracker=V00-01-00
 RecoBTag-Combined=V01-01-04
-PhysicsTools-NanoAOD=V01-00-05
 CalibCalorimetry-EcalTrivialCondModules=V00-02-00
 EgammaAnalysis-ElectronTools=V00-01-04
 RecoTauTag-TrainingFiles=V00-01-00


### PR DESCRIPTION
Move PhysicsTools-NanoAOD data to new tag, see 
https://github.com/npc-data/PhysicsTools-NanoAOD/pull/13
and 
https://api.github.com/repos/npc-data/PhysicsTools-NanoAOD/releases/17977202
